### PR TITLE
Fix: remove instant solve mode

### DIFF
--- a/InverseKinematicsLibrary/IKManager.cs
+++ b/InverseKinematicsLibrary/IKManager.cs
@@ -7,7 +7,7 @@ public class IKManager : MonoBehaviour
 {
     private HashSet<IKNode> nodes = new HashSet<IKNode>();
 
-    public enum SolveMode { runtime, instant, disabled, step};
+    public enum SolveMode { runtime, disabled, step};
     [SerializeField] private SolveMode _solveMode;
 
     /// <summary>
@@ -24,11 +24,7 @@ public class IKManager : MonoBehaviour
         _solveMode = updatedSolveMode;
 
         UpdateNodeSet();
-        if (_solveMode == SolveMode.instant)
-        {
-            SetNodesOperational(true);
-        }
-        else if (_solveMode == SolveMode.runtime)
+        if (_solveMode == SolveMode.runtime)
         {
             SetNodesOperational(Application.isPlaying);
         }

--- a/InverseKinematicsLibrary/IKNode.cs
+++ b/InverseKinematicsLibrary/IKNode.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 using System.Linq;
 using KinematicsLibrary;
 
-[ExecuteAlways]
 public class IKNode : MonoBehaviour
 {
     private IKNode parentNode;
@@ -35,19 +34,12 @@ public class IKNode : MonoBehaviour
 
     private void Update()
     {
-        if (Application.isPlaying && solving)
-        {
-            Solve();
-        }
+        Solve();
     }
     private void OnEnable()
     {
         parentNode = transform.parent.GetComponent<IKNode>();
         childNode = GetChildNodeOrNull();
-
-#if UNITY_EDITOR
-        UnityEditor.EditorApplication.update += Solve;
-#endif
     }
 
     private void OnTransformChildrenChanged()
@@ -61,13 +53,6 @@ public class IKNode : MonoBehaviour
         return transform.GetComponentsInChildren<IKNode>().Except(new[] { this }).FirstOrDefault();
     }
 
-    private void OnDisable()
-    {
-#if UNITY_EDITOR
-        UnityEditor.EditorApplication.update -= Solve;
-#endif
-    }
-    
     public void Solve()
     {
         // update and Editor loop.update both call Solve


### PR DESCRIPTION
Remove SolveMode.Instant. Address several issues in Unity editor with callbacks being attached, then encountering error, then never being possible to detach.